### PR TITLE
CMake: Fix desktop icon installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,8 @@ install(DIRECTORY data/gfx
 install(DIRECTORY data/sfx
 	DESTINATION "${KOBO_SHARE_DIR}"
 	FILES_MATCHING
-	PATTERN "*.a2s"
-	PATTERN "*.theme")
+	PATTERN "*.h"
+	PATTERN "*.agw")
 
 # Documentation
 file(GLOB doc_files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,8 @@ install(FILES ${doc_files}
 # Desktop entry
 if(NOT WIN32)
 	set(KOBO_DE_FILE "net.olofson.${KOBO_PACKAGE_NAME}.desktop")
-	install(FILES "${KOBODELUXE_SOURCE_DIR}/icons/kobodeluxe.png"
-		DESTINATION "share/pixmaps"
-		RENAME "${KOBO_PACKAGE_NAME}.png")
+	install(FILES "${KOBODELUXE_SOURCE_DIR}/icons/kobodl.png"
+		DESTINATION "share/pixmaps")
 	install(FILES "${KOBODELUXE_SOURCE_DIR}/icons/${KOBO_DE_FILE}"
 		DESTINATION "share/applications")
 endif(NOT WIN32)


### PR DESCRIPTION
Also .desktop file refers to kobodl as icon-name so should be left unchanged
